### PR TITLE
fix: Remove callout block from BlockObjectRequestWithoutChildren type

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -6592,15 +6592,6 @@ export type BlockObjectRequestWithoutChildren =
       object?: "block"
     }
   | {
-      callout: {
-        rich_text: Array<RichTextItemRequest>
-        icon?: PageIconRequest
-        color?: ApiColor
-      }
-      type?: "callout"
-      object?: "block"
-    }
-  | {
       synced_block: {
         synced_from: { block_id: IdRequest; type?: "block_id" } | null
       }


### PR DESCRIPTION
## Summary
This PR fixes the type definition for `callout` blocks by removing them from `BlockObjectRequestWithoutChildren`, as callout blocks can actually have children.

Fixes #575

## Problem
The `callout` block type was incorrectly included in both:
- `BlockObjectRequestWithoutChildren` (without children support)
- `BlockObjectRequest` (with children support)

This duplicate definition caused TypeScript to incorrectly prevent developers from adding children to callout blocks, even though the Notion UI and API both support nested content within callouts.

## Solution
Removed the `callout` block definition from `BlockObjectRequestWithoutChildren` (lines 6594-6602 in `src/api-endpoints.ts`). The correct definition with children support remains in `BlockObjectRequest`.

## Before
```typescript
// Callout couldn't have children in TypeScript
const callout = {
  type: "callout",
  callout: {
    rich_text: [{ text: { content: "Note" } }],
    children: [...] // ❌ TypeScript error!
  }
}
```

## After
```typescript
// Callout can now have children
const callout = {
  type: "callout",
  callout: {
    rich_text: [{ text: { content: "Note" } }],
    children: [...] // ✅ Works correctly!
  }
}
```

## Testing
- ✅ All existing tests pass
- ✅ TypeScript compilation successful
- ✅ Linting passes

## Notes
This change only affects TypeScript type definitions. No runtime behavior is changed. The Notion API already supports children in callout blocks; this PR simply corrects the SDK's type definitions to match the actual API behavior.